### PR TITLE
Make the shorthand expansion more strict to allow absolute repository urls

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:repository).provide(:git) do
 
   def expand_source(source)
     if source =~ /\A[^@\/\s]+\/[^\/\s]+\z/
-        @resource[:protocol]}://github.com/#{source}"
+        "#{@resource[:protocol]}://github.com/#{source}"
     else
       source
     end


### PR DESCRIPTION
This addresses boxen/our-boxen#60. 

Even if boxen is a Github product, it would be really nice to use it in heterogenous environments with self-hosted repositories or other services and not have to fork one of the core modules.
