### PR TITLE
OSX defaults wants a type.... sometimes

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -10,9 +10,10 @@ define boxen::osx_defaults(
 
   if $ensure == 'present' {
     if ($domain != undef) and ($key != undef) and ($value != undef) {
-      $cmd = "${defaults_cmd} write ${domain} ${key} '${value}'"
       if ($type != undef) {
         $cmd = "${defaults_cmd} write ${domain} ${key} -${type} '${value}'"
+      } else {
+        $cmd = "${defaults_cmd} write ${domain} ${key} '${value}'"
       }
       exec { "osx_defaults write ${domain}:${key}=>${value}":
         command => "${cmd}",


### PR DESCRIPTION
I was having issues with osx_defaults not setting certain variables and having them actually stick, especially boolean values. This adds the option to set a type along with the other values. If the option isn't set, it works as before.

Example:

```
boxen::osx_defaults { "Disable 'natural scrolling'":
  key    => 'com.apple.swipescrolldirection',
  domain => 'NSGlobalDomain',
  value  => 'false',
  type   => 'bool',
}
```

As soon as I added this, they started working. Maybe it's strictly related to Mountain Lion, but i'm not entirely sure.

Thanks for the great work so far!
