### PR TITLE
use boxen::config::repohost instead of github.com when cloning

### DIFF
--- a/lib/facter/boxen.rb
+++ b/lib/facter/boxen.rb
@@ -16,6 +16,10 @@ if config.respond_to? :reponame
   facts["boxen_reponame"] = config.reponame
 end
 
+if config.respond_to? :repohost
+  facts["boxen_repohost"] = config.repohost
+end
+
 facts["luser"]          = config.user
 
 Dir["#{config.homedir}/config/facts/*.json"].each do |file|

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,5 +1,6 @@
 class boxen::repo {
-  $remote_add = "git remote add origin https://github.com/${boxen::config::reponame}"
+  $clone_url = "https://${boxen::config::repohost}/${boxen::config::reponame}"
+  $remote_add = "git remote add origin ${clone_url}"
   $git_fetch = "git fetch -q origin"
   $git_reset = "git reset --hard origin/master"
 


### PR DESCRIPTION
depends on boxen/boxen#58.

@mdelagralfo mentioned wanting full control of the clone url. i'd like that too (a SSH clone url would be preferable in my organization), his PR might be preferable to this one.

/cc @wfarr
