### PR TITLE
repository command fails silently when the path has spaces

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'shellwords'
 
 Puppet::Type.type(:repository).provide(:git) do
   desc "Git repository clones"
@@ -29,7 +30,7 @@ Puppet::Type.type(:repository).provide(:git) do
         CRED_HELPER,
         [@resource[:extra]].flatten.join(' ').strip,
         source,
-        path
+        Shellwords.escape(path)
       ]
     else
       args = [
@@ -37,7 +38,7 @@ Puppet::Type.type(:repository).provide(:git) do
         "clone",
         [@resource[:extra]].flatten.join(' ').strip,
         source,
-        path
+        Shellwords.escape(path)
       ]
     end
 


### PR DESCRIPTION
I'm trying to clone directly to my sublimetext directory and it doesn't work. It says it successfully cloned, but it didn't. My guess is that spaces are not being escaped correctly

```
repository { "${home}/Library/Application Support/Sublime Text 3/Packages/Theme - Soda":
    source  => 'buymeasoda/soda-theme'
 }
```
