### PR TITLE
fix for GitHub usernames that have dashes

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -1,7 +1,8 @@
 class boxen::personal {
   $manifests = "${boxen::config::repodir}/modules/people/manifests"
-  $personal_manifest = "${manifests}/${::github_login}.pp"
+  $login = regsubst("${::github_login}", "-","_")
+  $personal_manifest = "${manifests}/${login}.pp"
   if file_exists($personal_manifest) {
-    include "people::${::github_login}"
+    include "people::${login}"
   }
 }


### PR DESCRIPTION
This amends the convention for people modules to use underscores in place of dashes, since dashes are invalid in puppet class names.  This should be sufficient since dashes are the only non-alphanumeric character allowed in GitHub usernames, per https://github.com/signup/free
