### PR TITLE
Fix the repository source regex

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -52,7 +52,9 @@ Puppet::Type.type(:repository).provide(:git) do
   end
 
   def expand_source(source)
-    if source =~ /\A\S+\/\S+\z/
+    # Catch anything that is simply "foo/bar", don't get things with
+    # // or @ in the first hunk.
+    if source =~ /\A[^\/\s@]+\/[^\/\s]+\z/
       "#{@resource[:protocol]}://github.com/#{source}"
     else
       source


### PR DESCRIPTION
The regex here was not correctly avoiding munging sources that had a protocol
in them (more than one /), or were a github style git@git ssh repo string. 
This new regex appears to avoid those repos correctly while still catching
foo/bar shorthands.

Most the credit here goes to github user kormoc for helping me fix the
most the regex.
