### PR TITLE
prevent osx_defaults booleans from applying every time

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -28,9 +28,17 @@ define boxen::osx_defaults(
         default => "${defaults_cmd}${host_option} write ${domain} ${key} -${type} '${value}'"
       }
 
+      if ($type =~ /^bool/) {
+        $checkvalue = $value ? {
+          /(true|yes)/ => '1',
+          /(false|no)/ => '0',
+        }
+      } else {
+        $checkvalue = $value
+      }
       exec { "osx_defaults write ${host} ${domain}:${key}=>${value}":
         command => $cmd,
-        unless  => "${defaults_cmd}${host_option} read ${domain} ${key} && (${defaults_cmd}${host_option} read ${domain} ${key} | awk '{ exit \$0 != \"${value}\" }')",
+        unless  => "${defaults_cmd}${host_option} read ${domain} ${key} && (${defaults_cmd}${host_option} read ${domain} ${key} | awk '{ exit \$0 != \"${checkvalue}\" }')",
         user    => $user
       }
     } # end present

--- a/spec/defines/osx_defaults_spec.rb
+++ b/spec/defines/osx_defaults_spec.rb
@@ -18,6 +18,48 @@ describe 'boxen::osx_defaults' do
       with(:command => "/usr/bin/defaults write #{domain} #{key} '#{value}'")
   end
 
+  context 'boolean handling' do
+    let(:params) {
+      { :domain => domain,
+        :key    => key,
+        :value  => value,
+        :type   => 'boolean',
+      }
+    }
+
+    context 'yes' do
+      let(:value) { 'yes' }
+      it 'converts yes to 1 for checking' do
+        should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"1\" }')")
+      end
+    end
+
+    context 'no' do
+      let(:value) { 'no' }
+      it 'converts no to 0 for checking' do
+        should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"0\" }')")
+      end
+    end
+
+    context 'true' do
+      let(:value) { 'true' }
+      it 'converts true to 1 for checking' do
+        should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"1\" }')")
+      end
+    end
+
+    context 'false' do
+      let(:value) { 'false' }
+      it 'converts false to 0 for checking' do
+        should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"0\" }')")
+      end
+    end
+  end
+
   context "with a host" do
     let(:params) {
       { :domain => domain,


### PR DESCRIPTION
`/usr/bin/defaults read` returns 0 / 1 for booleans, but
`/usr/bin/defaults write` only accepts true/false or yes/no as input, so
we need to map between input and the value we check cause our unless
condition to work properly.

closes #17
