### PR TITLE
Add cassandra, zookeeper, beanstalk, nsq & zeromq as project options

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -19,6 +19,21 @@
 #     mongodb =>
 #       If true, ensures mongodb is installed.
 #
+#     cassandra =>
+#       If true, ensures cassandra is installed.
+#
+#     zookeeper =>
+#       If true, ensures zookeeper is installed.
+#
+#     beanstalk =>
+#       If true, ensures beanstalk is installed.
+#
+#     nsq =>
+#       If true, ensures nsq is installed.
+#
+#     zeromq =>
+#       If true, ensures zeromq is installed.
+#
 #     mysql =>
 #       If set to true, ensures mysql is installed and creates databases named
 #       "${name}_development" and "${name}_test".
@@ -52,6 +67,11 @@ define boxen::project(
   $elasticsearch = undef,
   $memcached     = undef,
   $mongodb       = undef,
+  $cassandra     = undef,
+  $zookeeper     = undef,
+  $beanstalk     = undef,
+  $nsq           = undef,
+  $zeromq        = undef,
   $mysql         = undef,
   $nginx         = undef,
   $nodejs        = undef,
@@ -88,6 +108,26 @@ define boxen::project(
 
   if $mongodb {
     include mongodb
+  }
+
+  if $cassandra {
+    include cassandra
+  }
+
+  if $zookeeper {
+    include zookeeper
+  }
+
+  if $beanstalk {
+    include beanstalk
+  }
+
+  if $nsq {
+    include nsq
+  }
+
+  if $zeromq {
+    include zeromq
   }
 
   if $mysql {


### PR DESCRIPTION
This adds a few additional services as project options:
- Cassandra
- Zookeeper
- Beanstalk
- NSQ
- ZeroMQ

Note that the beanstalk option requires a beanstalk module, I've opened boxen/our-boxen#155 which provides this.
