### PR TITLE
Fix install-options

### DIFF
--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -80,7 +80,12 @@ Puppet::Type.type(:package).provide :homebrew,
     else
       # Nothing here? Nothing from before? Yay! It's a normal install.
 
-      run "boxen-install", resource[:name], *install_options
+      if install_options
+        run "install", resource[:name], *install_options
+      else
+        run "boxen-install", resource[:name]
+      end
+
     end
   end
 


### PR DESCRIPTION
I tryed

```
    package { "ghostscript":
      ensure => installed,
      install_options => [
                          '--with-x11'
                          ],
    }
```

it is not install_options install binary.
because, monky_pach(boxen-install) from S3.

I want have install_options binary.
so, have install_options case, use "brew install".
