### PR TITLE
Setting OSX defaults with a key with spaces requires it to be quoted.

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -9,12 +9,11 @@ define boxen::osx_defaults(
   $user   = undef,
   $type   = undef,
 ) {
-  $defaults_cmd = '/usr/bin/defaults'
-
-  $host_option = $host ? {
-    'currentHost' => ' -currentHost',
-    undef         => '',
-    default       => " -host ${host}"
+  $defaults_cmd  = '/usr/bin/defaults'
+  $default_cmds  = $host ? {
+    'currentHost' => [ $defaults_cmd, '-currentHost' ],
+    undef         => [ $defaults_cmd ],
+    default       => [ $defaults_cmd, '-host', $host ]
   }
 
   case $ensure {
@@ -23,36 +22,40 @@ define boxen::osx_defaults(
         fail('Cannot ensure present without domain, key, and value attributes')
       }
 
-      if ($type == undef) and (($value == true) or ($value == false)) {
+      if (($type == undef) and (($value == true) or ($value == false))) or ($type =~ /^bool/) {
         $type_ = 'bool'
-      } else {
-        $type_ = $type
-      }
 
-      $cmd = $type_ ? {
-        undef   => "${defaults_cmd}${host_option} write ${domain} '${key}' '${value}'",
-        default => "${defaults_cmd}${host_option} write ${domain} '${key}' -${type_} '${value}'"
-      }
-
-      if ($type_ =~ /^bool/) {
         $checkvalue = $value ? {
           /(true|yes)/ => '1',
           /(false|no)/ => '0',
         }
+
       } else {
+        $type_      = $type
         $checkvalue = $value
       }
+
+      $write_cmd = $type_ ? {
+        undef   => shellquote($default_cmds, 'write', $domain, $key, "${value}"),
+        default => shellquote($default_cmds, 'write', $domain, $key, "-${type_}", "${value}")
+      }
+
+      $read_cmd = shellquote($default_cmds, 'read', $domain, $key)
+
       exec { "osx_defaults write ${host} ${domain}:${key}=>${value}":
-        command => $cmd,
-        unless  => "${defaults_cmd}${host_option} read ${domain} '${key}' && (${defaults_cmd}${host_option} read ${domain} '${key}' | awk '{ exit \$0 != \"${checkvalue}\" }')",
+        command => $write_cmd,
+        unless  => "${read_cmd} && (${read_cmd} | awk '{ exit \$0 != \"${checkvalue}\" }')",
         user    => $user
       }
     } # end present
 
     default: {
+      $list_cmd   = shellquote($default_cmds, 'read', $domain)
+      $key_search = shellquote('grep', $key)
+
       exec { "osx_defaults delete ${host} ${domain}:${key}":
-        command => "${defaults_cmd}${host_option} delete ${domain} '${key}'",
-        onlyif  => "${defaults_cmd}${host_option} read ${domain} | grep '${key}'",
+        command => shellquote($default_cmds, 'delete', $domain, $key),
+        onlyif  => "${list_cmd} | ${key_search}",
         user    => $user
       }
     } # end default

--- a/spec/defines/osx_defaults_spec.rb
+++ b/spec/defines/osx_defaults_spec.rb
@@ -15,15 +15,38 @@ describe 'boxen::osx_defaults' do
 
   it do
     should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-      with(:command => "/usr/bin/defaults write #{domain} '#{key}' '#{value}'")
+      with(:command => "/usr/bin/defaults write #{domain} #{key} #{value}")
   end
 
-  context 'with a key with spaces' do
-    let(:key) { 'test key' }
+  context 'with quoting for shell values' do
+    let(:domain) { 'NSGlobalDomain With Space' }
+    let(:key)    { 'Key With Spaces' }
+    let(:value)  { 'Long String With Spaces' }
+    let(:host)   { 'com.example.long/host' }
 
-    it 'quotes the key' do
-      should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-        with(:command => "/usr/bin/defaults write #{domain} '#{key}' '#{value}'")
+    let(:default_params) {
+      { :domain => domain,
+        :key    => key,
+        :value  => value,
+        :host   => host
+      }
+    }
+    let(:params) { default_params }
+
+    context "for writing" do
+      it do
+        should contain_exec("osx_defaults write #{host} #{domain}:#{key}=>#{value}").
+          with(:command => "/usr/bin/defaults -host #{host} write \"#{domain}\" \"#{key}\" \"#{value}\"")
+      end
+    end
+
+    context "for deleting" do
+      let(:params) { default_params.merge(:ensure => 'delete') }
+
+      it do
+        should contain_exec("osx_defaults delete #{host} #{domain}:#{key}").
+          with(:command => "/usr/bin/defaults -host #{host} delete \"#{domain}\" \"#{key}\"")
+      end
     end
   end
 
@@ -40,7 +63,7 @@ describe 'boxen::osx_defaults' do
       let(:value) { 'yes' }
       it 'converts yes to 1 for checking' do
         should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-          with(:unless => "/usr/bin/defaults read #{domain} '#{key}' && (/usr/bin/defaults read #{domain} '#{key}' | awk '{ exit $0 != \"1\" }')")
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"1\" }')")
       end
     end
 
@@ -48,7 +71,7 @@ describe 'boxen::osx_defaults' do
       let(:value) { 'no' }
       it 'converts no to 0 for checking' do
         should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-          with(:unless => "/usr/bin/defaults read #{domain} '#{key}' && (/usr/bin/defaults read #{domain} '#{key}' | awk '{ exit $0 != \"0\" }')")
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"0\" }')")
       end
     end
 
@@ -56,7 +79,7 @@ describe 'boxen::osx_defaults' do
       let(:value) { 'true' }
       it 'converts true to 1 for checking' do
         should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-          with(:unless => "/usr/bin/defaults read #{domain} '#{key}' && (/usr/bin/defaults read #{domain} '#{key}' | awk '{ exit $0 != \"1\" }')")
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"1\" }')")
       end
     end
 
@@ -64,7 +87,7 @@ describe 'boxen::osx_defaults' do
       let(:value) { 'false' }
       it 'converts false to 0 for checking' do
         should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").
-          with(:unless => "/usr/bin/defaults read #{domain} '#{key}' && (/usr/bin/defaults read #{domain} '#{key}' | awk '{ exit $0 != \"0\" }')")
+          with(:unless => "/usr/bin/defaults read #{domain} #{key} && (/usr/bin/defaults read #{domain} #{key} | awk '{ exit $0 != \"0\" }')")
       end
     end
   end
@@ -80,7 +103,7 @@ describe 'boxen::osx_defaults' do
 
     it do
       should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").with(
-        :command => "/usr/bin/defaults write #{domain} '#{key}' -bool '#{value}'"
+        :command => "/usr/bin/defaults write #{domain} #{key} -bool #{value}"
       )
     end
   end
@@ -99,7 +122,7 @@ describe 'boxen::osx_defaults' do
 
       it do
         should contain_exec("osx_defaults write #{host} #{domain}:#{key}=>#{value}").
-          with(:command => "/usr/bin/defaults -currentHost write #{domain} '#{key}' '#{value}'")
+          with(:command => "/usr/bin/defaults -currentHost write #{domain} #{key} #{value}")
       end
     end
 
@@ -108,7 +131,7 @@ describe 'boxen::osx_defaults' do
 
       it do
         should contain_exec("osx_defaults write #{host} #{domain}:#{key}=>#{value}").
-          with(:command => "/usr/bin/defaults -host #{host} write #{domain} '#{key}' '#{value}'")
+          with(:command => "/usr/bin/defaults -host #{host} write #{domain} #{key} #{value}")
       end
     end
   end


### PR DESCRIPTION
Hi,

I was unable to set OSX defaults for things like iCal, as some of the keys have quotes.

As per example:
![Screen Shot 2013-04-02 at 11 19 17 AM](https://f.cloud.github.com/assets/19973/326298/d8eca5da-9b2b-11e2-93bf-d4e6d72aba83.png)

Attached code ensures the key value is quoted.

My current workaround to get this to work with boxen (before this pull request is merged) is to include in the key, which is a bit fugly:

```
boxen::osx_defaults::tommeier { "TimeZone support enabled":
    domain => 'com.apple.iCal',
    key    => "'TimeZone support enabled'",
    type   => boolean,
    value  => true
  }
```
