### PR TITLE
detect boolean values and set them correctly

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -23,12 +23,18 @@ define boxen::osx_defaults(
         fail('Cannot ensure present without domain, key, and value attributes')
       }
 
-      $cmd = $type ? {
-        undef   => "${defaults_cmd}${host_option} write ${domain} ${key} '${value}'",
-        default => "${defaults_cmd}${host_option} write ${domain} ${key} -${type} '${value}'"
+      if ($type == undef) and (($value == true) or ($value == false)) {
+        $type_ = 'bool'
+      } else {
+        $type_ = $type
       }
 
-      if ($type =~ /^bool/) {
+      $cmd = $type_ ? {
+        undef   => "${defaults_cmd}${host_option} write ${domain} ${key} '${value}'",
+        default => "${defaults_cmd}${host_option} write ${domain} ${key} -${type_} '${value}'"
+      }
+
+      if ($type_ =~ /^bool/) {
         $checkvalue = $value ? {
           /(true|yes)/ => '1',
           /(false|no)/ => '0',

--- a/spec/defines/osx_defaults_spec.rb
+++ b/spec/defines/osx_defaults_spec.rb
@@ -60,6 +60,22 @@ describe 'boxen::osx_defaults' do
     end
   end
 
+  context "with a boolean value" do
+    let(:value) { true }
+    let(:params) {
+      { :domain => domain,
+        :key    => key,
+        :value  => value
+      }
+    }
+
+    it do
+      should contain_exec("osx_defaults write  #{domain}:#{key}=>#{value}").with(
+        :command => "/usr/bin/defaults write #{domain} #{key} -bool '#{value}'"
+      )
+    end
+  end
+
   context "with a host" do
     let(:params) {
       { :domain => domain,


### PR DESCRIPTION
This makes osx_defaults notice when you pass a boolean value and automatically add the `-bool` argument to `defaults write`. This saves the user from remembering to specify the type in their manifest.

The main motivation is to make the upcoming customization stuff in boxen/puppet-osx#3 easier to use.
