### PR TITLE
GitHub Enterprise: Pulling repository url template from Boxen config

### DIFF
--- a/lib/facter/boxen.rb
+++ b/lib/facter/boxen.rb
@@ -18,8 +18,8 @@ end
 
 facts["luser"]          = config.user
 
-if config.respond_to? :repourl
-  facts["boxen_repo_url_template"] = config.repourl
+if config.respond_to? :repotemplate
+  facts["boxen_repo_url_template"] = config.repotemplate
 else
   facts["boxen_repo_url_template"] = "https://github.com/%s"
 end


### PR DESCRIPTION
It looks like puppet runs under sudo and doesn't have access to the required Boxen environment variable. This pull request pulls the url template from the config instead.

Contingent on boxen/boxen#70.
