### PR TITLE
Follow symbol links to ensure srcdir directory.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,8 +29,8 @@ class boxen::config {
           $envdir,
           $logdir,
           $socketdir]:
-    links => follow,
-    ensure => directory
+    ensure => directory,
+    links  => follow
   }
 
   file { "${home}/README.md":


### PR DESCRIPTION
Hi, 

My srcdir is linked to a disk under /Volumes.

I think it's better to follow symbol link when creating srcdir, then it will not delete my srcdir and create a new one.
