### PR TITLE
use homebrew/opt instead of homebrew/Library/LinkedKegs

### DIFF
--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:package).provide :homebrew,
   end
 
   def self.current(name)
-    link = Pathname.new "#{home}/Library/LinkedKegs/#{simplify name}"
+    link = Pathname.new "#{home}/opt/#{simplify name}"
     link.exist? && link.realpath.basename.to_s
   end
 


### PR DESCRIPTION
You know how `icu4c` appears to install itself every time you run? That's because it's an unlinked keg and we don't look for it in the right place.

Using `/opt/boxen/homebrew/opt` instead of `/opt/boxen/homebrew/Library/LinkedKegs` fixes this. `opt` contains symlinks to all installed kegs, instead of just the linked ones.
