### PR TITLE
Ensure permissions are properly set with converted dmg's

### DIFF
--- a/lib/puppet/provider/package/appdmg_eula.rb
+++ b/lib/puppet/provider/package/appdmg_eula.rb
@@ -26,6 +26,8 @@ Puppet::Type.type(:package).provide(:appdmg_eula, :parent => Puppet::Provider::P
   commands :hdiutil => "/usr/bin/hdiutil"
   commands :curl => "/usr/bin/curl"
   commands :ditto => "/usr/bin/ditto"
+  commands :chmod => "/bin/chmod"
+  commands :chown => "/usr/sbin/chown"
 
   # JJM We store a cookie for each installed .app.dmg in /var/db
   def self.instances_by_name
@@ -46,7 +48,10 @@ Puppet::Type.type(:package).provide(:appdmg_eula, :parent => Puppet::Provider::P
 
   def self.installapp(source, name, orig_source)
     appname = File.basename(source);
-    ditto "--rsrc", source, "/Applications/#{appname}"
+    target = "/Applications/#{appname}"
+    ditto "--rsrc", source, "#{target}"
+    chmod "-R", "a+xr", "#{target}"
+    chown "-R", "#{Facter[:boxen_user].value}:admin", "#{target}"
     File.open("/var/db/.puppet_appdmg_installed_#{name}", "w") do |t|
       t.print "name: '#{name}'\n"
       t.print "source: '#{orig_source}'\n"


### PR DESCRIPTION
I had some errors with an EULA'd app I was installing -- until these permissions were set, OSX was thinking it was invalid.
