### PR TITLE
Resubmit: Fix people::hoge_foo_bar doesn't include properly.

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -2,7 +2,7 @@
 
 class boxen::personal {
   $manifests         = "${boxen::config::repodir}/modules/people/manifests"
-  $login             = regsubst($::github_login, '-','_')
+  $login             = regsubst($::github_login, '-','_','G')
   $personal_manifest = "${manifests}/${login}.pp"
 
   if file_exists($personal_manifest) {


### PR DESCRIPTION
Boxen will try to include people::hoge_foo-bar but do nothing since there is no file for that.

This PR is the resubmitting version of #44
