### PR TITLE
correctly check for FDE

### DIFF
--- a/lib/facter/root_encrypted.rb
+++ b/lib/facter/root_encrypted.rb
@@ -4,7 +4,7 @@ Facter.add("root_encrypted") do
   config = Boxen::Config.load
 
   def root_encrypted?
-    system("/usr/sbin/diskutil coreStorage info / > /dev/null 2>&1")
+    system("/usr/bin/fdesetup isactive /")
   end
 
   setcode do


### PR DESCRIPTION
Soooo this shit has never actually worked correctly.

On a fresh format/install, `diskutil coreStorage info` will fail because the disk hasn't been converted to CS yet. If you enable and then disable FDE, it will continue to return true because at that point the disk _has_ been converted.

Fortunately, Apple anticipated this and gave us the lovely `fdesetup isactive` command, which actually does the right thing. I've verified that it does the right thing on a fresh machine, a machine with FDE enabled, and a machine that has FDE enabled and then disabled. I am very confident in this change. @jbarnette and/or @wfarr please take a quick look.

For what it's worth, `fdesetup` can also be used to enable FDE but that's more than I'm willing to bite off right now.
