### PR TITLE
Include mysql module if project depends on it

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -131,7 +131,7 @@ define boxen::project(
   }
 
   if $mysql {
-    include mysql
+    require mysql
 
     $mysql_dbs = $mysql ? {
       true    => ["${name}_development", "${name}_test"],


### PR DESCRIPTION
Projects requiring mysql fail hard otherwise

```
Error: Puppet::Parser::AST::Resource failed with error ArgumentError: Invalid resource type mysql::db at /opt/boxen/repo/shared/boxen/manifests/project.pp:139 on node articulate.local
```
