### PR TITLE
allow boxen runs during fde-ing

### DIFF
--- a/lib/facter/root_encrypted.rb
+++ b/lib/facter/root_encrypted.rb
@@ -4,8 +4,8 @@ Facter.add("root_encrypted") do
   config = Boxen::Config.load
 
   def root_encrypted?
-    is_active = `/usr/bin/fdesetup isactive ; echo $?`.chomp
-	  is_active == "0" || is_active == "2" ? true : false
+    system("/usr/bin/fdesetup isactive /")
+    [0, 2].include? $?
   end
 
   setcode do


### PR DESCRIPTION
On older Mac Books with large spinny drives it can sometime take up to many several hours for a disk to be fully encrypted. Having someone wait that time before they can get rocking with Boxen is a little silly. 

[From the Apple Man pages from fdesetup](http://developer.apple.com/library/Mac/documentation/Darwin/Reference/ManPages/man8/fdesetup.8.html) an Exit Status of `2` indicates that FDE is _ON_ just busy.

However one side note, if you turn FDE _OFF_ the Exit Status will return `2` while the disk is decrypting, but all subsequent Boxen runs will fail unless the `--no-fde` flag is passed. 
