### PR TITLE
Support refreshonly in osx_defaults

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -17,7 +17,7 @@ define boxen::osx_defaults(
     undef         => '',
     default       => " -host ${host}"
   }
-  
+
   case $ensure {
     present: {
       if ($domain == undef) or ($key == undef) or ($value == undef) {


### PR DESCRIPTION
Some settings might be set only conditionally upon other resources refreshing. For this scenario, it would be a good idea to support refreshonly inside the `boxen::osx_defaults` type.

This comes from me trying to manage my desktop background with boxen. I only want to run the `osx_defaults` that changes the background resource when the file actually changes.

The code (that I would like to have):

``` puppet
  $desktop_file = "/Users/${::boxen_user}/.desktop.png"

  file { $desktop_file:
    ensure => present,
    source => "puppet:///modules/people/foca/wallpaper.png";
  }

  boxen::osx_defaults { "Set desktop background":
    domain      => "com.apple.Desktop",
    key         => "Background",
    value       => "{default = {ImageFilePath = \"${desktop_file}\";};}",
    refreshonly => true, # BOOM
    subscribe   => File[$desktop_file],
    notify      => Exec["Restart the Dock"];
  }

  exec { "Restart the Dock":
    command     => "killall Dock",
    refreshonly => true;
  }
```

The code I ended up with:

``` puppet
  $desktop_file = "/Users/${::boxen_user}/.desktop.png"

  file { $desktop_file:
    ensure => present,
    source => "puppet:///modules/people/foca/wallpaper.png";
  }

  exec { "Set desktop background":
    command     => "defaults write com.apple.Desktop Background '{default = {ImageFilePath = \"${desktop_file}\";};}'",
    unless      => "defaults read com.apple.Desktop Background | grep '${desktop_file}'",
    refreshonly => true,
    subscribe   => File[$desktop_file],
    notify      => Exec["Restart the Dock"];
  }

  exec { "Restart the Dock":
    command     => "killall Dock",
    refreshonly => true;
  }
```

Does this make sense? :)
