### PR TITLE
Fix bug in checking exitstatus from fdesetup

### DIFF
--- a/lib/facter/root_encrypted.rb
+++ b/lib/facter/root_encrypted.rb
@@ -5,7 +5,7 @@ Facter.add("root_encrypted") do
 
   def root_encrypted?
     system("/usr/bin/fdesetup isactive /")
-    [0, 2].include? $?
+    [0, 2].include? $?.exitstatus
   end
 
   setcode do


### PR DESCRIPTION
When fdesetup returns with exit code 2, $? is actually 512 (512 >> 8 == 2). Need to check for $?.exitstatus
