### PR TITLE
Don't add 'bin' to $PATH

### DIFF
--- a/templates/env.sh.erb
+++ b/templates/env.sh.erb
@@ -29,11 +29,6 @@ for f in $BOXEN_HOME/env.d/*.sh ; do
   fi
 done
 
-# Add ./bin to the path. This happens after initialization to make
-# sure local stubs take precedence over stuff like rbenv.
-
-export PATH=bin:$PATH
-
 # Boxen is active.
 
 if [ -d "$BOXEN_HOME/repo/.git" ]; then


### PR DESCRIPTION
This is a terrible idea - I could put bin/ls somewhere, and trick you in to running Bad Things. If you're running stuff locally, do it explicitly like ./bin/x, or `bundle exec` for ruby

Alternatively if you want this on your path, set something up in your own .profile or manifest - shouldn't be forced globally in an un-modifiable manner.

Re-submitting because boxen/puppet-boxen#42 got closed.
