### PR TITLE
Add homedir to plist search path to enable agents provided by the user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle
+/.idea
 /.ruby-version
 /spec/fixtures/.librarian
 /spec/fixtures/.tmp

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "json"
 gem "cardboard", "~> 2.1"
 # Puppet 3.4 breaks all the things, notably the module-data module
 gem "puppet", "< 3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,5 +65,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json
   cardboard (~> 2.1)
   puppet (< 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
   cardboard (~> 2.1)
+  json
   puppet (< 3.4)

--- a/lib/puppet/provider/service/ghlaunchd.rb
+++ b/lib/puppet/provider/service/ghlaunchd.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
   commands :launchctl => "/bin/launchctl",
             :plutil   => "/usr/bin/plutil",
@@ -9,10 +11,11 @@ Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
   mk_resource_methods
 
   LAUNCHD_DIRS = [
+    "~/Library/LaunchAgents",
     "/Library/LaunchAgents",
     "/Library/LaunchDaemons",
     "/System/Library/LaunchAgents",
-    "/System/Library/LaunchDaemons"
+    "/System/Library/LaunchDaemons",
   ]
 
   def restart
@@ -105,8 +108,8 @@ Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
     return @plist_file if defined? @plist_file
 
     name = "#{resource[:name]}.plist"
-    glob = "{" + LAUNCHD_DIRS.join(",") + "}/#{name}"
+    pattern = "{" + LAUNCHD_DIRS.join(",") + "}/#{name}"
 
-    @plist_file = Dir[glob].first.to_s or raise "Can't find #{name}."
+    @plist_file = Dir.glob(pattern).first.to_s or raise "Can't find #{name}."
   end
 end

--- a/lib/puppet/provider/service/ghlaunchd.rb
+++ b/lib/puppet/provider/service/ghlaunchd.rb
@@ -57,10 +57,14 @@ Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
     end
   end
 
+  def start_after_load?
+    config['inetdCompatibility'].nil?
+  end
+
   def start
     return false if plist_file.to_s.empty?
     maybe_sudo_launchctl :load, "-w", plist_file
-    if config['inetdCompatibility'].nil?
+    if start_after_load?
       maybe_sudo_launchctl :start, resource[:name]
     end
   rescue => e

--- a/lib/puppet/provider/service/ghlaunchd.rb
+++ b/lib/puppet/provider/service/ghlaunchd.rb
@@ -2,9 +2,9 @@ require 'json'
 
 Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
   commands :launchctl => "/bin/launchctl",
-            :plutil   => "/usr/bin/plutil",
-            :rm       => "/bin/rm",
-            :sudo     => "/usr/bin/sudo"
+           :plutil    => "/usr/bin/plutil",
+           :rm        => "/bin/rm",
+           :sudo      => "/usr/bin/sudo"
 
   confine :operatingsystem => :darwin
 
@@ -12,7 +12,7 @@ Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
   mk_resource_methods
 
   def boxen_user
-    Facter.fact(:boxen_user).value
+    Facter.fact(:boxen_user).value.to_s
   end
 
   def run_as_boxen_user?
@@ -35,7 +35,7 @@ Puppet::Type.type(:service).provide :ghlaunchd, :parent => :base do
   end
 
   def maybe_sudo_launchctl(*args)
-    if run_as_boxen_user? then
+    if run_as_boxen_user?
       sudo('-u', boxen_user, command(:launchctl), *args)
     else
       launchctl(*args)

--- a/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
+++ b/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
@@ -1,0 +1,28 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:service).provider(:ghlaunchd) do
+  let(:subject) {
+    resource = Puppet::Type.type(:service).hash2resource({:name => 'some.vendor.service'})
+    described_class.new(resource)
+  }
+
+  describe "start" do
+
+    it "should start a service with a plist file" do
+      Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])
+        
+      subject.stubs(:plutil).returns('{}')
+      subject.expects(:launchctl).with(:load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+      subject.expects(:launchctl).with(:start, 'some.vendor.service')
+      subject.start
+    end
+
+    it "should not start a service without a plist file" do
+      Dir.stubs(:glob).returns([])
+
+      subject.expects(:launchctl).never()
+      subject.start.should == false
+    end
+  end
+end

--- a/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
+++ b/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
@@ -9,31 +9,98 @@ describe Puppet::Type.type(:service).provider(:ghlaunchd) do
 
   describe "start" do
 
-    it "should start a launch agent with sudo" do
-      Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])
-      Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+    context "with some service plist" do
 
-      subject.stubs(:plutil).returns('{}')
-      subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-      subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
-      subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service')
-      subject.start
+      it "should load a launch agent with sudo" do
+        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])        
+        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+
+        subject.stubs(:plutil).returns('{}')
+        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service')
+        subject.start
+      end
+
+      it "should load but not start a inetd compatible launch agent" do
+        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])        
+        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+
+        subject.stubs(:plutil).returns('{}')
+        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+        subject.stubs(:config).returns({'inetdCompatibility' => {}})
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service').never()
+        subject.start
+      end  
+
+      it "should load a launch deamon without sudo" do
+        Dir.stubs(:glob).returns(['/Library/LaunchDeamons/some.vendor.service.plist'])
+
+        subject.stubs(:plutil).returns('{}')
+        subject.expects(:launchctl).with(:load, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
+        subject.expects(:launchctl).with(:start, 'some.vendor.service')
+        subject.start
+      end
     end
 
-    it "should not start without a plist file" do
+    context "without some service plist" do
       Dir.stubs(:glob).returns([])
 
-      subject.expects(:launchctl).never()
-      subject.start.should == false
-    end
+      it "should not load a launch agent" do
+        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
 
-    it "should start a launch deamon without sudo" do
-      Dir.stubs(:glob).returns(['/Library/LaunchDeamons/some.vendor.service.plist'])
+        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never()
+        subject.start.should be_false
+      end
 
-      subject.stubs(:plutil).returns('{}')
-      subject.expects(:launchctl).with(:load, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
-      subject.expects(:launchctl).with(:start, 'some.vendor.service')
-      subject.start
+      it "should not load a launch deamon" do
+        subject.expects(:launchctl).with(:load).never()
+        subject.start.should be_false
+      end
     end
   end
+
+  describe "stop" do
+
+    context "with some service plist" do
+    
+      it "should unload a launch agent" do
+        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])
+        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+
+        subject.stubs(:plutil).returns('{}')
+        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :unload, '-w','/Library/LaunchAgents/some.vendor.service.plist')
+        subject.stop
+      end
+
+      it "should unload a launch deamon" do
+        Dir.stubs(:glob).returns(['/Library/LaunchDeamons/some.vendor.service.plist'])        
+
+        subject.stubs(:plutil).returns('{}')
+        subject.expects(:launchctl).with(:unload, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
+        subject.stop
+      end
+    end
+
+    context "without some service plist" do
+      Dir.stubs(:glob).returns([])
+
+      it "should not unload a launch agent" do
+        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+
+        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never()
+        subject.stop.should be_false
+      end
+
+      it "should not unload a launch deamon" do
+        subject.expects(:launchctl).with(:unload).never()
+        subject.stop.should be_false
+      end
+    end
+  end
+
 end

--- a/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
+++ b/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
@@ -6,57 +6,61 @@ describe Puppet::Type.type(:service).provider(:ghlaunchd) do
     resource = Puppet::Type.type(:service).hash2resource({:name => 'some.vendor.service'})
     described_class.new(resource)
   }
+  let(:facts) {{
+    :operatingsystem => 'darwin'
+  }}
+
+  Facter.add('boxen_user') { setcode { 'some_user' } }
 
   describe "start" do
 
     context "with some service plist" do
 
       it "should load a launch agent with sudo" do
-        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])        
-        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+        Dir.stub(:glob).and_return(['/Library/LaunchAgents/some.vendor.service.plist'])
 
-        subject.stubs(:plutil).returns('{}')
-        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service')
+        subject.stub(:plutil).and_return('{}')
+        subject.stub(:command).with(:launchctl).and_return('/bin/launchctl')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service')
         subject.start
       end
 
       it "should load but not start a inetd compatible launch agent" do
-        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])        
-        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+        Dir.stub(:glob).and_return(['/Library/LaunchAgents/some.vendor.service.plist'])
 
-        subject.stubs(:plutil).returns('{}')
-        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-        subject.stubs(:config).returns({'inetdCompatibility' => {}})
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service').never()
+        subject.stub(:plutil).and_return('{}')
+        subject.stub(:command).with(:launchctl).and_return('/bin/launchctl')
+        subject.stub(:config).and_return({'inetdCompatibility' => {}})
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service').never
         subject.start
-      end  
+      end
 
       it "should load a launch deamon without sudo" do
-        Dir.stubs(:glob).returns(['/Library/LaunchDeamons/some.vendor.service.plist'])
+        Dir.stub(:glob).and_return(['/Library/LaunchDeamons/some.vendor.service.plist'])
 
-        subject.stubs(:plutil).returns('{}')
-        subject.expects(:launchctl).with(:load, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
-        subject.expects(:launchctl).with(:start, 'some.vendor.service')
+        subject.stub(:plutil).and_return('{}')
+        subject.should_receive(:launchctl).with(:load, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
+        subject.should_receive(:launchctl).with(:start, 'some.vendor.service')
         subject.start
       end
     end
 
     context "without some service plist" do
-      Dir.stubs(:glob).returns([])
 
       it "should not load a launch agent" do
-        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+        Dir.stub(:glob).and_return([])
 
-        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never()
+        subject.stub(:command).with(:launchctl).and_return('/bin/launchctl')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never
         subject.start.should be_false
       end
 
       it "should not load a launch deamon" do
-        subject.expects(:launchctl).with(:load).never()
+        Dir.stub(:glob).and_return([])
+
+        subject.should_receive(:launchctl).with(:load).never
         subject.start.should be_false
       end
     end
@@ -65,39 +69,39 @@ describe Puppet::Type.type(:service).provider(:ghlaunchd) do
   describe "stop" do
 
     context "with some service plist" do
-    
-      it "should unload a launch agent" do
-        Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])
-        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
 
-        subject.stubs(:plutil).returns('{}')
-        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :unload, '-w','/Library/LaunchAgents/some.vendor.service.plist')
+      it "should unload a launch agent" do
+        Dir.stub(:glob).and_return(['/Library/LaunchAgents/some.vendor.service.plist'])
+
+        subject.stub(:plutil).and_return('{}')
+        subject.stub(:command).with(:launchctl).and_return('/bin/launchctl')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :unload, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
         subject.stop
       end
 
       it "should unload a launch deamon" do
-        Dir.stubs(:glob).returns(['/Library/LaunchDeamons/some.vendor.service.plist'])        
+        Dir.stub(:glob).and_return(['/Library/LaunchDeamons/some.vendor.service.plist'])
 
-        subject.stubs(:plutil).returns('{}')
-        subject.expects(:launchctl).with(:unload, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
+        subject.stub(:plutil).and_return('{}')
+        subject.should_receive(:launchctl).with(:unload, '-w', '/Library/LaunchDeamons/some.vendor.service.plist')
         subject.stop
       end
     end
 
     context "without some service plist" do
-      Dir.stubs(:glob).returns([])
 
       it "should not unload a launch agent" do
-        Facter.stubs(:fact).with(:boxen_user).returns(stub(:value => 'some_user'))
+        Dir.stub(:glob).and_return([])
 
-        subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
-        subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never()
+        subject.stub(:command).with(:launchctl).and_return('/bin/launchctl')
+        subject.should_receive(:sudo).with('-u', 'some_user', '/bin/launchctl', :load).never
         subject.stop.should be_false
       end
 
       it "should not unload a launch deamon" do
-        subject.expects(:launchctl).with(:unload).never()
+        Dir.stub(:glob).and_return([])
+
+        subject.should_receive(:launchctl).with(:unload).never
         subject.stop.should be_false
       end
     end

--- a/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
+++ b/spec/unit/puppet/provider/service/ghlaunchd_spec.rb
@@ -24,5 +24,16 @@ describe Puppet::Type.type(:service).provider(:ghlaunchd) do
       subject.expects(:launchctl).never()
       subject.start.should == false
     end
+
+    it "should sudo to user if user is defined" do
+      subject.stubs(:plutil).returns('{}')
+      Dir.stubs(:glob).returns(['/Library/LaunchAgents/some.vendor.service.plist'])
+
+      subject.stubs(:user).returns('some_user')
+      subject.stubs(:command).with(:launchctl).returns('/bin/launchctl')
+      subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :load, '-w', '/Library/LaunchAgents/some.vendor.service.plist')
+      subject.expects(:sudo).with('-u', 'some_user', '/bin/launchctl', :start, 'some.vendor.service')
+      subject.start
+    end
   end
 end


### PR DESCRIPTION
I tried to launch a custom per-user agent as the current user with the launchd service provider but failed. My plist was located at ```~/Library/LaunchAgents/my.custom.service.plist```. The cause was that the home dir is not part of the pattern to find the plist file. I also added some tests for the start method of the service provider.