### PR TITLE
Log a message on changed username in boxen::personal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 /spec/fixtures/.librarian
 /spec/fixtures/.tmp
 /spec/fixtures/Puppetfile.lock
-/spec/fixtures/modules
 /spec/fixtures/vendor
+/spec/fixtures/modules
+!/spec/fixtures/modules/projects
+!/spec/fixtures/modules/people

--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -1,11 +1,15 @@
 # Private: Includes a user's personal manifest based on their github username
 
 class boxen::personal {
-  $manifests         = "${boxen::config::repodir}/modules/people/manifests"
-  $login             = regsubst($::github_login, '-','_', 'G')
-  $personal_manifest = "${manifests}/${login}.pp"
+  include boxen::config
 
-  if file_exists($personal_manifest) {
+  $manifests = "${boxen::config::repodir}/modules/people/manifests"
+  $login     = regsubst($boxen::config::login, '-','_', 'G')
+
+  if $login != $boxen::config::login {
+    notice("Changed boxen::personal login to ${login}")
+  }
+  if file_exists("${manifests}/${login}.pp") {
     include "people::${login}"
   }
 }

--- a/spec/classes/personal_spec.rb
+++ b/spec/classes/personal_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'boxen::personal' do
+  
+  context "username with dash" do
+    let(:facts) do
+      {
+        :boxen_home => '/opt/boxen',
+        :boxen_repodir => 'spec/fixtures',
+        :github_login => 'some-username',
+      }
+    end
+
+    it { should include_class('boxen::config')}
+    it { should include_class('people::some_username')}
+  end
+end

--- a/spec/fixtures/modules/people/manifests/some_username.pp
+++ b/spec/fixtures/modules/people/manifests/some_username.pp
@@ -1,0 +1,1 @@
+class people::some_username {}


### PR DESCRIPTION
When i tried boxen first i stumbled over that boxen plays not nice with a username that includes dash, which is a limitation of puppet. So it should log a message if the dash is replaced by an underscore to make it more transparent whats going on. I also added a test to document the current behavior.
