### PR TITLE
Avoid NoMethodError by removing explicit receiver.

### DIFF
--- a/lib/puppet/provider/package/appdmg_eula.rb
+++ b/lib/puppet/provider/package/appdmg_eula.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:package).provide(:appdmg_eula, :parent => Puppet::Provider::P
 
   def self.installpkgdmg(source, name)
     unless source =~ /\.dmg$/i
-      self.fail "Mac OS X PKG DMG's must specify a source string ending in .dmg"
+      fail "Mac OS X PKG DMG's must specify a source string ending in .dmg"
     end
     require 'open-uri'
     require 'facter/util/plist'
@@ -122,10 +122,10 @@ Puppet::Type.type(:package).provide(:appdmg_eula, :parent => Puppet::Provider::P
   def install
     source = nil
     unless source = @resource[:source]
-      self.fail "Mac OS X PKG DMG's must specify a package source."
+      fail "Mac OS X PKG DMG's must specify a package source."
     end
     unless name = @resource[:name]
-      self.fail "Mac OS X PKG DMG's must specify a package name."
+      fail "Mac OS X PKG DMG's must specify a package name."
     end
     self.class.installpkgdmg(source,name)
   end

--- a/lib/puppet/provider/package/compressed_app.rb
+++ b/lib/puppet/provider/package/compressed_app.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:package).provide :compressed_app,
                   when source =~ /\.tbz$/i
                     'tbz'
                   else
-                    self.fail "Source must be one of .zip, .tar.gz, .tgz, .tar.bz2, .tbz"
+                    fail "Source must be one of .zip, .tar.gz, .tgz, .tar.bz2, .tbz"
                   end
 
 
@@ -104,16 +104,16 @@ Puppet::Type.type(:package).provide :compressed_app,
 
   def install
     unless source = @resource[:source]
-      self.fail "OS X compressed apps must specify a package source"
+      fail "OS X compressed apps must specify a package source"
     end
 
     unless name = @resource[:name]
-      self.fail "OS X compressed apps must specify a package name"
+      fail "OS X compressed apps must specify a package name"
     end
 
     if flavor = @resource[:flavor]
       unless SOURCE_TYPES.member? flavor
-        self.fail "Unsupported flavor"
+        fail "Unsupported flavor"
       end
     end
 


### PR DESCRIPTION
This was causing errors like this:

Could not set 'present' on ensure: private method `fail' called for Puppet::Type::Package::ProviderAppdmg_eula:Class