### PR TITLE
boxen::bin should depend on boxen::repo

### DIFF
--- a/manifests/bin.pp
+++ b/manifests/bin.pp
@@ -2,6 +2,7 @@
 
 class boxen::bin {
   include boxen::config
+  include boxen::repo
 
   file { "${boxen::config::home}/bin/boxen":
     ensure  => link,


### PR DESCRIPTION
bin/boxen depends on the boxen repo being cloned.

```
Error: Could not find dependency Exec[clone /opt/boxen/repo] for File[/opt/boxen/bin/boxen]
```

/cc @dgoodlad @wfarr 
