### PR TITLE
Support subdirs for projects

### DIFF
--- a/lib/puppet/parser/functions/include_all_projects.rb
+++ b/lib/puppet/parser/functions/include_all_projects.rb
@@ -3,12 +3,14 @@ module Puppet::Parser::Functions
     Puppet::Parser::Functions.function('include')
 
     repo = "#{Facter[:boxen_home].value}/repo"
-    Dir["#{repo}/modules/projects/manifests/*.pp"].each do |project|
-      class_name = project.split('/').last
+    prefix = "#{repo}/modules/projects/manifests"
+    Dir["#{prefix}/**/*.pp"].each do |path|
+      project = path.gsub /^#{prefix}\/|\.pp$/, ''
+      class_name = project.gsub /\//, '::'
 
-      next if class_name =~ /all\.pp$/
+      next if class_name == 'all'
 
-      function_include [class_name.gsub(/\.pp$/, '')]
+      function_include [class_name]
     end
   end
 end

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -36,7 +36,7 @@
 #
 #     mysql =>
 #       If set to true, ensures mysql is installed and creates databases named
-#       "${name}_development" and "${name}_test".
+#       "${underscored_name}_development" and "${underscored_name}_test".
 #       If set to any string or array value, creates those databases instead.
 #
 #     nginx =>
@@ -46,7 +46,7 @@
 #
 #     postgresql =>
 #       If set to true, ensures postgresql is installed and creates databases
-#       named "${name}_development" and "${name}_test".
+#       named "${underscored_name}_development" and "${underscored_name}_test".
 #       If set to any string or array value, creates those databases instead.
 #
 #     redis =>
@@ -83,7 +83,8 @@ define boxen::project(
   $redis         = undef,
   $ruby          = undef,
   $phantomjs     = undef,
-  $server_name   = "${name}.dev",
+  $server_name   = regsubst(regsubst($name, '[^a-zA-Z0-9]+', '-', 'G'), '$','.dev'),
+  $underscored_name = regsubst($name, '[^a-zA-Z0-9]+', '_', 'G'),
 ) {
   include boxen::config
 
@@ -139,7 +140,7 @@ define boxen::project(
     require mysql
 
     $mysql_dbs = $mysql ? {
-      true    => ["${name}_development", "${name}_test"],
+      true    => ["${underscored_name}_development", "${underscored_name}_test"],
       default => $mysql,
     }
 
@@ -155,7 +156,7 @@ define boxen::project(
       default => $nginx,
     }
 
-    file { "${nginx::config::sitesdir}/${name}.conf":
+    file { "${nginx::config::sitesdir}/${underscored_name}.conf":
       content => template($nginx_templ),
       require => File[$nginx::config::sitesdir],
       notify  => Service['dev.nginx'],
@@ -171,7 +172,7 @@ define boxen::project(
 
   if $postgresql {
     $psql_dbs = $postgresql ? {
-      true    => ["${name}_development", "${name}_test"],
+      true    => ["${underscored_name}_development", "${underscored_name}_test"],
       default => $postgresql,
     }
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -161,6 +161,12 @@ define boxen::project(
       require => File[$nginx::config::sitesdir],
       notify  => Service['dev.nginx'],
     }
+
+    $socket_dir = dirname("${boxen::config::socketdir}/${name}")
+    file { $socket_dir:
+      ensure => directory,
+      require => File[$boxen::config::socketdir]
+    }
   }
 
   if $nodejs {

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -162,10 +162,20 @@ define boxen::project(
       notify  => Service['dev.nginx'],
     }
 
-    $socket_dir = dirname("${boxen::config::socketdir}/${name}")
-    file { $socket_dir:
-      ensure  => directory,
-      require => File[$boxen::config::socketdir]
+    $project_ext = dirname($name)
+    $socket_dir = "${boxen::config::socketdir}/${project_ext}"
+    $log_dir = "${nginx::config::logdir}/${project_ext}"
+    if(!defined(File[$socket_dir])) {
+      file { $socket_dir:
+	ensure  => directory,
+	require => File[$boxen::config::socketdir]
+      }
+    }
+    if(!defined(File[$log_dir])) {
+      file { $log_dir:
+	ensure  => directory,
+	require => File[$boxen::config::logdir]
+      }
     }
   }
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -164,7 +164,7 @@ define boxen::project(
 
     $socket_dir = dirname("${boxen::config::socketdir}/${name}")
     file { $socket_dir:
-      ensure => directory,
+      ensure  => directory,
       require => File[$boxen::config::socketdir]
     }
   }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -167,14 +167,14 @@ define boxen::project(
     $log_dir = "${nginx::config::logdir}/${project_ext}"
     if(!defined(File[$socket_dir])) {
       file { $socket_dir:
-	ensure  => directory,
-	require => File[$boxen::config::socketdir]
+        ensure  => directory,
+        require => File[$boxen::config::socketdir]
       }
     }
     if(!defined(File[$log_dir])) {
       file { $log_dir:
-	ensure  => directory,
-	require => File[$boxen::config::logdir]
+        ensure  => directory,
+        require => File[$boxen::config::logdir]
       }
     }
   }


### PR DESCRIPTION
I work for several clients and want to keep their projects namespaced in Boxen e.g. `projects::awesomeclient::amazingproject` in `modules/projects/manifests/awesomeclient/amazingproject.pp`.

It's entirely possible to do this using underscores, but it doesn't feel as nice as having separate directories for each client.

Note that this may change the name of some servers where an underscore was used in the project name. I prefer this way, but I can alter the code to support having underscores too, either way.
