### PR TITLE
Fix broken fact for enforcing full disk encryption

### DIFF
--- a/lib/facter/root_encrypted.rb
+++ b/lib/facter/root_encrypted.rb
@@ -1,5 +1,5 @@
 Facter.add("root_encrypted") do
-  confine :os_family => 'Darwin'
+  confine :osfamily => 'Darwin'
 
   def root_encrypted?
     system("/usr/bin/fdesetup isactive / >/dev/null")


### PR DESCRIPTION
The core fact we want to check is called `osfamily`, not `os_family`:
http://docs.puppetlabs.com/facter/1.7/core_facts.html#osfamily

Right now this fact is never being run, so the code from the sample Boxen project to enforce full disk encryption doesn't work:
https://github.com/boxen/our-boxen/blob/565e3e96a69644f5a6eb4179f559fb327c55cb87/manifests/site.pp#L62-L64
