### PR TITLE
Revert "The correct type for the askForPassword is boolean"

### DIFF
--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -1,7 +1,7 @@
 # Private: A basic security profile for Boxen boxes
 
 class boxen::security(
-  $require_password = true,
+  $require_password = 1,
   $screensaver_delay_sec = 5
 ) {
   boxen::osx_defaults { 'require password at screensaver':
@@ -9,7 +9,7 @@ class boxen::security(
     domain => 'com.apple.screensaver',
     key    => 'askForPassword',
     value  => $require_password,
-    type   => 'bool',
+    type   => 'int',
     user   => $::boxen_user
   }
 


### PR DESCRIPTION
This reverts commit c2a7258f28438d147492ec39b873aa464515ce74.

I believe that `askForPassword` actually is an integer. To demonstrate:

``` bash
$ /usr/bin/defaults read-type com.apple.screensaver askForPassword
Type is integer
```

As is, this commit is creating a perma-diff for me as the integer value isn't equal to a boolean.
