### PR TITLE
Override appdmg provider

### DIFF
--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -1,0 +1,108 @@
+# Jeff McCune <mccune.jeff@gmail.com>
+# Changed to app.dmg by: Udo Waechter <root@zoide.net>
+# Mac OS X Package Installer which handles application (.app)
+# bundles inside an Apple Disk Image.
+#
+# Motivation: DMG files provide a true HFS file system
+# and are easier to manage.
+#
+# Note: the 'apple' Provider checks for the package name
+# in /L/Receipts.  Since we possibly install multiple apps's from
+# a single source, we treat the source .app.dmg file as the package name.
+# As a result, we store installed .app.dmg file names
+# in /var/db/.puppet_appdmg_installed_<name>
+
+require 'puppet/provider/package'
+Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Package) do
+  desc "Package management which copies application bundles to a target."
+
+  confine :operatingsystem => :darwin
+
+  commands :hdiutil => "/usr/bin/hdiutil"
+  commands :curl => "/usr/bin/curl"
+  commands :ditto => "/usr/bin/ditto"
+  commands :chown => "/usr/sbin/chown"
+
+  # JJM We store a cookie for each installed .app.dmg in /var/db
+  def self.instances_by_name
+    Dir.entries("/var/db").find_all { |f|
+      f =~ /^\.puppet_appdmg_installed_/
+    }.collect do |f|
+      name = f.sub(/^\.puppet_appdmg_installed_/, '')
+      yield name if block_given?
+      name
+    end
+  end
+
+  def self.instances
+    instances_by_name.collect do |name|
+      new(:name => name, :provider => :appdmg, :ensure => :installed)
+    end
+  end
+
+  def self.installapp(source, name, orig_source)
+    appname = File.basename(source);
+    ditto "--rsrc", source, "/Applications/#{appname}"
+    chown "-R", "#{Facter[:boxen_user].value}:staff", "#{target}"
+    File.open("/var/db/.puppet_appdmg_installed_#{name}", "w") do |t|
+      t.print "name: '#{name}'\n"
+      t.print "source: '#{orig_source}'\n"
+    end
+  end
+
+  def self.installpkgdmg(source, name)
+    require 'open-uri'
+    require 'facter/util/plist'
+    cached_source = source
+    tmpdir = Dir.mktmpdir
+    begin
+      if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
+        cached_source = File.join(tmpdir, name)
+        begin
+          curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
+          Puppet.debug "Success: curl transfered [#{name}]"
+        rescue Puppet::ExecutionFailure
+          Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."
+          cached_source = source
+        end
+      end
+
+      open(cached_source) do |dmg|
+        xml_str = hdiutil "mount", "-plist", "-nobrowse", "-readonly", "-mountrandom", "/tmp", dmg.path
+          ptable = Plist::parse_xml xml_str
+          # JJM Filter out all mount-paths into a single array, discard the rest.
+          mounts = ptable['system-entities'].collect { |entity|
+            entity['mount-point']
+          }.select { |mountloc|; mountloc }
+          begin
+            mounts.each do |fspath|
+              Dir.entries(fspath).select { |f|
+                f =~ /\.app$/i
+              }.each do |pkg|
+                installapp("#{fspath}/#{pkg}", name, source)
+              end
+            end
+          ensure
+            hdiutil "eject", mounts[0]
+          end
+      end
+    ensure
+      FileUtils.remove_entry_secure(tmpdir, true)
+    end
+  end
+
+  def query
+    Puppet::FileSystem.exist?("/var/db/.puppet_appdmg_installed_#{@resource[:name]}") ? {:name => @resource[:name], :ensure => :present} : nil
+  end
+
+  def install
+    source = nil
+    unless source = @resource[:source]
+      self.fail "Mac OS X PKG DMG's must specify a package source."
+    end
+    unless name = @resource[:name]
+      self.fail "Mac OS X PKG DMG's must specify a package name."
+    end
+    self.class.installpkgdmg(source,name)
+  end
+end


### PR DESCRIPTION
I recently noticed that the `appdmg` provider isn't setting ownership on the applications it installs.

I've attempted to override the default puppet appdmg provider and add in the chown step (copied from `appdmg_eula`).

cc/ @dgoodlad
