### PR TITLE
Don't allow insecure SSL connections

### DIFF
--- a/lib/puppet/provider/package/appdmg_eula.rb
+++ b/lib/puppet/provider/package/appdmg_eula.rb
@@ -71,7 +71,7 @@ Puppet::Type.type(:package).provide(:appdmg_eula, :parent => Puppet::Provider::P
       if %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ cached_source
         cached_source = File.join(tmpdir, name)
         begin
-          curl "-o", cached_source, "-C", "-", "-k", "-L", "-s", "--url", source
+          curl "-o", cached_source, "-C", "-", "-L", "-s", "--url", source
           Puppet.debug "Success: curl transfered [#{name}]"
         rescue Puppet::ExecutionFailure
           Puppet.debug "curl did not transfer [#{name}].  Falling back to slower open-uri transfer methods."


### PR DESCRIPTION
The `appdmg_eula` provider was calling `curl` with `-k` which allows curl'ing over insecure HTTPS connections. I can't see why this would ever be desired, and one package (boxen/puppet-gpgtools) would often fail when attempting to download an .dmg from their server.

This PR removes the insecure option.
