### PR TITLE
Remove homebrew refs from top-level env.sh

### DIFF
--- a/templates/env.sh.erb
+++ b/templates/env.sh.erb
@@ -11,14 +11,6 @@ set +u
 
 export BOXEN_HOME=<%= scope.lookupvar "boxen::config::home" %>
 
-# Add homebrew'd stuff to the path.
-
-PATH=$BOXEN_HOME/homebrew/bin:$BOXEN_HOME/homebrew/sbin:$PATH
-
-# Add homebrew'd stuff to the manpath.
-
-export MANPATH=$BOXEN_HOME/homebrew/share/man:$MANPATH
-
 # Add any binaries specific to Boxen to the path.
 
 PATH=$BOXEN_HOME/bin:$PATH


### PR DESCRIPTION
These should get set by a script controlled in boxen/puppet-homebrew

See boxen/puppet-homebrew#73
