### PR TITLE
Use the Boxen API token as GITHUB_API_TOKEN

### DIFF
--- a/templates/gh_creds.sh.erb
+++ b/templates/gh_creds.sh.erb
@@ -1,3 +1,4 @@
 # Expose GitHub credentials
 
 export BOXEN_GITHUB_LOGIN=<%= scope.lookupvar('boxen::config::login') %>
+export GITHUB_API_TOKEN=`security find-generic-password -w -s 'GitHub API Token' "/Users/<%= scope.lookupvar('boxen::config::user') %>/Library/Keychains/login.keychain"`


### PR DESCRIPTION
A common complaint I see in Boxen issues revolves around the user not having set `GITHUB_API_TOKEN`, thus causing rate-limiting to break puppet-librarian and other commands that use the GitHub API. Would something like this be useful?
