### PR TITLE
fix duplication declaration errors for boxen::personal::includes and boxen::personal::osx_apps

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -41,12 +41,12 @@ class boxen::personal (
   #   include projects::foo
   #   include projects::bar
   $project_classes = prefix($projects, 'projects::')
-  class { $project_classes: }
+  ensure_resource('class', $project_classes)
 
   # If $includes looks like ['foo', 'bar'], behaves like:
   # class { 'foo': }
   # class { 'bar': }
-  class { $includes: }
+  ensure_resource('class', $includes)
 
   # $casks and $osx_apps are synonyms. $osx_apps takes precedence
   $_casks = $osx_apps ? {

--- a/spec/fixtures/hiera/common.yaml
+++ b/spec/fixtures/hiera/common.yaml
@@ -1,0 +1,3 @@
+---
+boxen::personal::includes:
+  - boxen::config

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - common
+  - username
+:yaml:
+  :datadir: 'spec/fixtures/hiera'

--- a/spec/fixtures/hiera/username.yaml
+++ b/spec/fixtures/hiera/username.yaml
@@ -1,0 +1,3 @@
+---
+boxen::personal::includes:
+  - boxen::config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,5 @@ RSpec.configure do |c|
   c.mock_framework = :rspec
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 end


### PR DESCRIPTION
I was using ``boxen::personal::includes`` in both ``common.yaml`` and ``users/github_login.yaml``. Some classes were repeated in both classes. When I run ``boxen``, some duplicate declarations exceptions were thrown, this pr helps avoid those.
thanks