### PR TITLE
Add --binarydir to brewcask install_options

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -57,7 +57,8 @@ class boxen::personal (
   if count($_casks) > 0 { include brewcask }
   ensure_resource('package', $_casks, {
     'provider'        => 'brewcask',
-    'install_options' => '--appdir=/Applications',
+    'install_options' => ['--appdir=/Applications',
+                          "--binarydir=${boxen::config::homebrewdir}/bin"],
   })
 
   # If any homebrew packages are specified , declare them


### PR DESCRIPTION
This is the PR for the problem I originally mentioned in the discussion of [PR119](https://github.com/boxen/puppet-boxen/pull/119#issuecomment-72324010).

I run into a small problem when I wanted to install Textmate:

```yaml
boxen::personal::osx_apps:
  - textmate
```

```bash
Error: Execution of 'brew cask install textmate --appdir=/Applications' returned 1: ==> Downloading https://api.textmate.org/downloads/release
==> Symlinking App 'TextMate.app' to '/Applications/TextMate.app'
Error: Permission denied - /usr/local
==> Symlinking Binary 'mate' to '/usr/local/bin/mate'
```

The Textmate cask tries to symlink a helper binary to `/usr/local/bin/mate`. Since Boxen does not touch `/usr/local` by default the permissions are wrong and `/usr/local/bin` does not even exist.

As far as I can tell, we should install the helper into `/opt/boxen/homebrew/bin` instead. According to https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md the corresponding brew cask option is `--binarydir=/opt/boxen/homebrew/bin`.

I tested my changes by unistalling Textmate manually with `brew cask uninstall textmate`, deleting the Puppetfile.lock, replacing the puppet-boxen module in the Puppetfile with my local fork and running `script/boxen` again. This time Textmate installed without a problem and `mate` is symlinked as `/opt/boxen/homebrew/bin/mate` as expected.