### PR TITLE
Value isn't being evaluated correctly when using --future-parser in osx defaults

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -27,8 +27,10 @@ define boxen::osx_defaults(
         $type_ = 'bool'
 
         $checkvalue = $value ? {
-          /(true|yes)/ => '1',
-          /(false|no)/ => '0',
+          true => '1',
+          false => '0',
+          'yes' => '1',
+          'no' => '0'
         }
 
       } else {


### PR DESCRIPTION
There appears to be a problem with how $value is being evaluated. I think this is fixable using 3.7.4 and Puppet's scanf but I haven't tried.

I got around the problem by breaking the selector into 4 parts: true, false, yes, no, rather than using a regex on two. Not as elegant but my Puppet / Ruby knowledge is limited.
