### PR TITLE
Make sure Personal homebrew_packages are always at their latest version

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -1,4 +1,5 @@
-# Private: Includes a user's personal configuration based on their GitHub username
+# Private: Includes a user's personal configuration based
+#          on their GitHub username
 #
 # Usage:
 #
@@ -88,6 +89,7 @@ class boxen::personal (
     default   => $homebrew_packages
   }
   ensure_resource('package', $_homebrew_packages, {
+    'ensure'   => 'latest',
     'provider' => 'homebrew',
   })
 

--- a/spec/unit/puppet/provider/package/appdmg_eula_spec.rb
+++ b/spec/unit/puppet/provider/package/appdmg_eula_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:package).provider(:appdmg_eula) do
       it "should call tmpdir and use the returned directory" do
         Dir.should_receive(:mktmpdir).and_return tmpdir
         Dir.stub(:entries).and_return ["foo.app"]
-        described_class.should_receive(:curl).with('-o', "#{tmpdir}/foo", '-C', '-', '-k', '-L', '-s', '--url', source)
+        described_class.should_receive(:curl).with('-o', "#{tmpdir}/foo", '-C', '-', '-L', '-s', '--url', source)
         described_class.should_receive(:hdiutil).with('convert', '/tmp/foo', '-format', 'UDTO', '-o', '/tmp/good123/appdmg_eula')
         described_class.should_receive(:hdiutil).with('attach', '-plist', '-nobrowse', '-readonly', '-noverify', '-noautoopen', '-mountrandom', '/tmp', "#{tmpdir}/appdmg_eula.cdr").and_return(fake_hdiutil_plist)
         described_class.should_receive(:installapp)


### PR DESCRIPTION
When specifying homebrew_packages to install via the yaml hash key ``boxen::personal::homebrew_packages``, this PR makes sure, on a boxen run, there are always on their latest version.

This PR also includes a cleanup of an outdated test.

Thanks

cc @rafaelfranca 