### PR TITLE
pass empty array as default instead of undef

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -53,7 +53,7 @@ class boxen::personal (
   # class { 'foo': }
   # class { 'bar': }
   $_includes = $merge_hierarchy ? {
-    true      => hiera_array("${name}::includes",undef),
+    true      => hiera_array("${name}::includes",[]),
     default   => $includes
   }
   ensure_resource('class', $_includes)
@@ -85,7 +85,7 @@ class boxen::personal (
 
   # If any homebrew packages are specified , declare them
   $_homebrew_packages = $merge_hierarchy ? {
-    true      => hiera_array("${name}::homebrew_packages",undef),
+    true      => hiera_array("${name}::homebrew_packages",[]),
     default   => $homebrew_packages
   }
   ensure_resource('package', $_homebrew_packages, {


### PR DESCRIPTION
Hey there,

So if you try to use `merge_hierarchy` for something like just aggregating osx_apps without explicitly declaring includes or homebrew_packages, puppet squawks with duplicate declaration or resource errors.

```
With no includes declared:
Error: Duplicate declaration: Class[main] is already declared; cannot redeclare at /opt/boxen/repo/shared/boxen/manifests/personal.pp:59 on node hms-thunderdunk.stedwards.edu
Error: Duplicate declaration: Class[main] is already declared; cannot redeclare at /opt/boxen/repo/shared/boxen/manifests/personal.pp:59 on node hms-thunderdunk.stedwards.edu

With no homebrew_packages declared:
Error: Could not find resource 'Package[]' for relationship from 'Homebrew_repo[/opt/boxen/homebrew]' on node hms-thunderdunk.stedwards.edu
Error: Could not find resource 'Package[]' for relationship from 'Homebrew_repo[/opt/boxen/homebrew]' on node hms-thunderdunk.stedwards.edu
```

This just sets the default datatype to the same empty array we already use when `merge_hierarchy` is false.

Let me know if this needs any other work. :heart: 
