### PR TITLE
remove deprecated and default options

### DIFF
--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -78,9 +78,7 @@ class boxen::personal (
   # If any casks/osx_apps are specified, declare them as brewcask packages
   if count($_casks) > 0 { include brewcask }
   ensure_resource('package', $_casks, {
-    'provider'        => 'brewcask',
-    'install_options' => ['--appdir=/Applications',
-                          "--binarydir=${boxen::config::homebrewdir}/bin"],
+    'provider'        => 'brewcask'
   })
 
   # If any homebrew packages are specified , declare them


### PR DESCRIPTION
brew cask now defaults to the appdir of /Applications, and has removed the --binarydir option entirely. removing these options fixes a deprecation warning printed during every cask installation.