### PR TITLE
Add support for dotfiles to `boxen::personal`

### DIFF
--- a/manifests/dotfiles.pp
+++ b/manifests/dotfiles.pp
@@ -1,3 +1,20 @@
+# Private: Manage dotfiles.
+#
+# Usage:
+#
+#   boxen:dotfiles { 'dotfiles':
+#     repository      => 'https://github.com/user/dotfiles',
+#     local_directory => '.dotfiles',
+#     install_command => 'install.sh'
+#   }
+#
+# Parameters:
+#
+#   repository      - Git repository URL.
+#   local_directory - Local location of where you would like to clone
+#                     and manage the repository.
+#   install_command - Script or inline command that you use to setup
+#                     your repository.
 define boxen::dotfiles(
   $repository      = undef,
   $local_directory = 'dotfiles',

--- a/manifests/dotfiles.pp
+++ b/manifests/dotfiles.pp
@@ -30,7 +30,7 @@ define boxen::dotfiles(
   }
 
   if $install_command {
-    exec { "install dotfiles":
+    exec { 'install dotfiles':
       cwd      => $dotfiles_dir,
       command  => $install_command,
       provider => shell,

--- a/manifests/dotfiles.pp
+++ b/manifests/dotfiles.pp
@@ -1,0 +1,24 @@
+define boxen::dotfiles(
+  $repository      = undef,
+  $local_directory = 'dotfiles',
+  $install_command = undef,
+) {
+  require boxen::config
+
+  $home = "/Users/${::boxen_user}"
+  $dotfiles_dir = "${boxen::config::srcdir}/${local_directory}"
+
+  repository { $dotfiles_dir:
+    source => $repository,
+  }
+
+  if $install_command {
+    exec { "install dotfiles":
+      cwd      => $dotfiles_dir,
+      command  => $install_command,
+      provider => shell,
+      creates  => $dotfiles_dir,
+      require  => Repository[$dotfiles_dir]
+    }
+  }
+}

--- a/manifests/personal.pp
+++ b/manifests/personal.pp
@@ -25,6 +25,7 @@ class boxen::personal (
   $osx_apps          = undef,
   $homebrew_packages = [],
   $custom_projects   = {},
+  $dotfiles          = {},
 ){
   include boxen::config
 
@@ -109,4 +110,8 @@ class boxen::personal (
     default   => $custom_projects
   }
   create_resources(boxen::project, $_custom_projects)
+
+  if !empty($dotfiles) {
+    ensure_resource('boxen::dotfiles', 'dotfiles', $dotfiles)
+  }
 }


### PR DESCRIPTION
For a while now many people have been managing their dotfiles either
outside of Boxen or using their own custom modules. While not a bad
thing, it definitely adds some pain to using Boxen.

To address this, I've added a new `boxen::dotfiles` resource. In a bid
to keep this integration as agnostic as possible, you only need to
define two parameters, `repository` and `install_command`. The
repository is the git URL you would like to fetch the settings from and
the `install_command` is what will trigger the setup of your dotfiles in
whatever manner you desire. Here is an example using hiera:

```yaml
boxen::personal::dotfiles:
  repository: https://github.com/example/dotfiles.git
  install_command: './install.sh'
```

The plan here is that we keep the specifics of how you manage your
dotfiles **out of Boxen** and inside of the repository itself.

Closes #141