### PR TITLE
Move the Boxen package configuration to `/etc`

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,7 +2,7 @@
 boxen::config::home:        "%{::boxen_home}"
 boxen::config::bindir:      "%{::boxen_home}/bin"
 boxen::config::cachedir:    "%{::boxen_home}/cache"
-boxen::config::configdir:   "%{::boxen_home}/config"
+boxen::config::configdir:   "%{::homebrew_root}/etc/boxen"
 boxen::config::datadir:     "%{::boxen_home}/data"
 boxen::config::envdir:      "%{::boxen_home}/env.d"
 boxen::config::homebrewdir: "%{::homebrew_root}"


### PR DESCRIPTION
In boxen/puppet-nginx#51 we were receiving "Operation not permitted"
errors when trying to install nginx configuration files to
`/opt/boxen/config` due to a restriction introduced in Homebrew
1.3.0[1].

To address the installation issue, we need to move the configuration
files to `%{::homebrew_root}/etc/boxen` however to maintain a "what does Boxen
manage" list we're going to chuck it in `boxen` sub directory. The end
result should be:

```
/usr/local/etc/boxen/:service
```